### PR TITLE
feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@
 *.exe
 *.out
 *.app
+
+mpags-cipher


### PR DESCRIPTION
Looks good.

This pull request only add `mpags-cipher` to `.gitignore`.

I have a few comments.
- if `-h` or `--help` is given the program should exit after showing the help message
- the option `--version` should be implemented.
- git commit messages: I recommend to follow [this note](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
    - write in the present tense. (a commit message describes what the commit does as a patch rather than describing what you did.)
    - start with a short one line description.
    - if you need add a long description, add a blank line after the short description, then continue with the long description.
     
